### PR TITLE
Basic setup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,9 +6,8 @@ module.exports = function(grunt) {
         doctest: {
             test: {
                 options: {
-                    files: ['test/toFarenheit.js'],
                     module: 'commonjs',
-                    glob: '**/*'
+                    glob: '{test/**/*.js,tasks/**/*.js}'
                 }
             }
         }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        doctest: {
+            test: {
+                options: {
+                    files: ['test/toFarenheit.js'],
+                    module: 'commonjs',
+                    glob: '**/*'
+                }
+            }
+        }
+    });
+
+    grunt.loadTasks('tasks');
+
+    // Default task(s).
+    grunt.registerTask('default', ['test']);
+    grunt.registerTask('test', ['doctest:test'])
+
+};

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2014 Paolo del Mundo
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-doctest [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-uglify.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-uglify) <a href="https://ci.appveyor.com/project/gruntjs/grunt-contrib-uglify"><img src="https://ci.appveyor.com/api/projects/status/ybtf5vbvtenii561/branch/master" alt="Build Status: Windows" height="18" /></a>
+# grunt-doctest
 
 > Run doctest from grunt
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,74 @@
-grunt-doctest
-=============
+# grunt-doctest [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-uglify.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-uglify) <a href="https://ci.appveyor.com/project/gruntjs/grunt-contrib-uglify"><img src="https://ci.appveyor.com/api/projects/status/ybtf5vbvtenii561/branch/master" alt="Build Status: Windows" height="18" /></a>
+
+> Run doctest from grunt
+
+
+
+## Getting Started
+This plugin requires Grunt `^0.4.0`
+
+If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
+
+```shell
+npm install grunt-doctest --save-dev
+```
+
+Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
+
+```js
+grunt.loadNpmTasks('grunt-doctest');
+```
+
+
+
+
+## Doctest task
+_Run this task with the `grunt doctest` command._
+
+Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
+
+### Options
+
+
+#### glob
+
+Type: `String` {String} Pattern to be matched.
+Default: null
+
+Specify the files you want to run doctests on.
+
+
+#### module
+
+Type: `String` {commonjs | amd}
+Default: `commonjs`
+
+The module system your project is using.
+
+### Usage examples
+
+#### Basic configuration
+
+This configuration will run doctests on the javascript files in the test and tasks folders, even in subfolders.
+
+```js
+// Project configuration.
+grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    doctest: {
+        test: {
+            options: {
+                module: 'commonjs',
+                glob: '{test/**/*.js,tasks/**/*.js}'
+            }
+        }
+    }```
+
+
+## Release History
+
+ * 2014-06-06   v1.0.0   First official release of grunt-doctest.
+---
+
+Task submitted by [Paolo del Mundo](http://paolodm.com/)
+

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "grunt-doctest",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "grunt plugin for https://github.com/davidchambers/doctest",
-  "main": "index.js",
   "scripts": {
     "test": "grunt test"
   },
   "author": "Paolo del Mundo",
   "license": "MIT",
   "devDependencies": {
-    "grunt": "^0.4.5"
+    "grunt": "^0.4.0"
   },
   "dependencies": {
+    "chalk": "^0.4.0",
     "doctest": "^0.6.1",
     "glob": "^4.0.2",
     "lodash": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "grunt-doctest",
+  "version": "0.0.0",
+  "description": "grunt plugin for https://github.com/davidchambers/doctest",
+  "main": "index.js",
+  "scripts": {
+    "test": "grunt test"
+  },
+  "author": "Paolo del Mundo",
+  "license": "MIT",
+  "devDependencies": {
+    "grunt": "^0.4.5"
+  },
+  "dependencies": {
+    "doctest": "^0.6.1",
+    "glob": "^4.0.2",
+    "lodash": "^2.4.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-doctest",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "grunt plugin for https://github.com/davidchambers/doctest",
   "scripts": {
     "test": "grunt test"

--- a/tasks/doctest.js
+++ b/tasks/doctest.js
@@ -2,21 +2,58 @@
 
 var doctest = require('doctest'),
     _ = require('lodash'),
-    glob = require('glob');
+    glob = require('glob'),
+    chalk = require('chalk');
+
+/*
+convertResultArrayToObject -> Array -> Object
+
+doctest returns results in an array
+This function converts the array to an object, so it would be easier to
+work with.
+
+> convertResultArrayToObject([true, 10, 10, 5])
+{ pass: true, expected: 10, actual: 10, lineNumber: 5 }
+*/
+function convertResultArrayToObject(result) {
+    return {
+        pass: result[0],
+        expected: result[1],
+        actual: result[2],
+        lineNumber: result[3]
+    };
+}
 
 module.exports = function(grunt) {
     grunt.registerMultiTask('doctest', 'Run doctests against files', function() {
         var options = this.options({
-            module: 'commonjs'
-        });
+                module: 'commonjs'
+            }),
+            files = glob.sync(options.glob, { cwd: '.' });
 
-        _.each(options.files, function(f) {
-            console.log('file: ' + f);
+        function runDoctests(files) {
+            _.each(files, function(file) {
+                console.log('Running doctest for ' + file + '...');
 
-            var result = doctest(f, {
-                module: options.module
+                var results = doctest(file, {
+                    module: options.module
+                });
+
+                _(results)
+                    .map(convertResultArrayToObject)
+                    .each(function(result) {
+                        if (result.pass) {
+                            console.log(chalk.green("\tPassed on line " + result.lineNumber));
+                        }
+                        else {
+                            console.log(chalk.red("\tFailed on line " + result.lineNumber + ".\n" +
+                                "\t\tExpected: " + result.expected + "\n" +
+                                "\t\tActual: " + result.actual + "\n"));
+                        }
+                    });
             });
-            console.log('r', result);
-        });
+        }
+
+        runDoctests(files);
     });
 };

--- a/tasks/doctest.js
+++ b/tasks/doctest.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var doctest = require('doctest'),
+    _ = require('lodash'),
+    glob = require('glob');
+
+module.exports = function(grunt) {
+    grunt.registerMultiTask('doctest', 'Run doctests against files', function() {
+        var options = this.options({
+            module: 'commonjs'
+        });
+
+        _.each(options.files, function(f) {
+            console.log('file: ' + f);
+
+            var result = doctest(f, {
+                module: options.module
+            });
+            console.log('r', result);
+        });
+    });
+};

--- a/test/toFarenheit.js
+++ b/test/toFarenheit.js
@@ -7,7 +7,7 @@
 // > toFahrenheit(0)
 // 32
 // > toFahrenheit(100)
-// 211
+// 212
 function toFahrenheit(degreesCelsius) {
     return degreesCelsius * 9 / 5 + 32;
 }

--- a/test/toFarenheit.js
+++ b/test/toFarenheit.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// toFahrenheit :: Number -> Number
+//
+// Convert degrees Celsius to degrees Fahrenheit.
+//
+// > toFahrenheit(0)
+// 32
+// > toFahrenheit(100)
+// 211
+function toFahrenheit(degreesCelsius) {
+    return degreesCelsius * 9 / 5 + 32;
+}


### PR DESCRIPTION
### As an end user of grunt-doctest, I want to be able to  get the results of my doctests.

Acceptance Criteria: 

grunt-doctest will take the following options:

module, i.e. commonjs, amd
fileGlob, i.e. '*_/_.js'

I expect to get the results of the doctests from the expanded fileGlob. The build should fail if one of my doctests fails. I expect to see the error description, the file and line number where the doctest failed.
